### PR TITLE
TOTP: copy generated OTP code to clipboard instead of the secret key

### DIFF
--- a/app/src/main/java/com/yogeshpaliyal/keypass/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/yogeshpaliyal/keypass/ui/home/HomeFragment.kt
@@ -58,13 +58,20 @@ class HomeFragment : Fragment() {
             }
         }
 
+        private fun getPassword(model: AccountModel): String {
+            if (model.type == AccountType.TOTP) {
+                return model.getOtp()
+            }
+            return model.password.orEmpty()
+        }
+
         override fun onCopyClicked(model: AccountModel) {
             val clipboard =
                 ContextCompat.getSystemService(
                     requireContext(),
                     ClipboardManager::class.java
                 )
-            val clip = ClipData.newPlainText("KeyPass", model.password)
+            val clip = ClipData.newPlainText("KeyPass", getPassword(model))
             clipboard?.setPrimaryClip(clip)
             Toast.makeText(context, getString(R.string.copied_to_clipboard), Toast.LENGTH_SHORT)
                 .show()

--- a/common/src/main/java/com/yogeshpaliyal/common/data/AccountModel.kt
+++ b/common/src/main/java/com/yogeshpaliyal/common/data/AccountModel.kt
@@ -60,7 +60,7 @@ open class AccountModel(
             ?: notes?.firstOrNull() ?: 'K'
         ).toString()
 
-    fun getOtp() = TOTPHelper.generate(password)
+    fun getOtp(): String = TOTPHelper.generate(password)
 
     fun getTOtpProgress() = TOTPHelper.getProgress().toInt()
 }


### PR DESCRIPTION
Currently, when clicking on the clipboard copy button for TOTP, the secret key is copied to the clipboard.
This changes the behavior to copy the generated OTP instead.