### PR TITLE
Generate password activity to compose migration

### DIFF
--- a/keypasscompose/build.gradle
+++ b/keypasscompose/build.gradle
@@ -36,6 +36,10 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
         useIR = true
+
+        freeCompilerArgs += [
+                '-Xopt-in=androidx.compose.material3.ExperimentalMaterial3Api'
+        ]
     }
     buildFeatures {
         compose true

--- a/keypasscompose/build.gradle
+++ b/keypasscompose/build.gradle
@@ -84,9 +84,13 @@ dependencies {
     api project(":common")
 
     implementation "androidx.compose.ui:ui:1.3.3"
-    implementation "androidx.compose.material:material:1.3.1"
+    implementation "androidx.compose.material:material:1.4.0-alpha04"
     implementation "androidx.compose.ui:ui-tooling-preview:1.3.3"
     implementation 'androidx.activity:activity-compose:1.5.1'
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
+    implementation "androidx.lifecycle:lifecycle-runtime-compose:2.6.0-alpha03"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1"
+    implementation "androidx.compose.material:material-icons-extended:1.3.1"
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.3.3"
     debugImplementation "androidx.compose.ui:ui-tooling:1.3.3"
 

--- a/keypasscompose/build.gradle
+++ b/keypasscompose/build.gradle
@@ -95,6 +95,7 @@ dependencies {
     debugImplementation "androidx.compose.ui:ui-tooling:1.3.3"
 
     implementation 'androidx.compose.material3:material3:1.1.0-alpha04'
+    implementation "com.google.accompanist:accompanist-themeadapter-material3:0.28.0"
 
 
     // XML Libraries

--- a/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/GeneratePasswordActivity.kt
+++ b/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/GeneratePasswordActivity.kt
@@ -31,6 +31,7 @@ class GeneratePasswordActivity : AppCompatActivity() {
             viewModel.generatePassword()
         }
 
+        addOnFormChangeListeners()
         collectStateFlows()
 
         binding.tilPassword.setEndIconOnClickListener {
@@ -38,6 +39,44 @@ class GeneratePasswordActivity : AppCompatActivity() {
             val clip = ClipData.newPlainText("random_password", binding.etPassword.text)
             clipboard.setPrimaryClip(clip)
             Toast.makeText(this, getString(R.string.copied_to_clipboard), Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun addOnFormChangeListeners() {
+        onLengthSliderValueChange()
+        onUppercaseCheckedChange()
+        onLowercaseCheckedChange()
+        onNumberCheckedChange()
+        onSymbolCheckedChange()
+    }
+
+    private fun onLengthSliderValueChange() {
+        binding.sliderPasswordLength.addOnChangeListener { _, value, _ ->
+            viewModel.onPasswordLengthSliderChange(value)
+        }
+    }
+
+    private fun onUppercaseCheckedChange() {
+        binding.cbCapAlphabets.setOnCheckedChangeListener { _, checked ->
+            viewModel.onUppercaseCheckedChange(checked)
+        }
+    }
+
+    private fun onLowercaseCheckedChange() {
+        binding.cbLowerAlphabets.setOnCheckedChangeListener { _, checked ->
+            viewModel.onLowercaseCheckedChange(checked)
+        }
+    }
+
+    private fun onNumberCheckedChange() {
+        binding.cbNumbers.setOnCheckedChangeListener { _, checked ->
+            viewModel.onNumbersCheckedChange(checked)
+        }
+    }
+
+    private fun onSymbolCheckedChange() {
+        binding.cbSymbols.setOnCheckedChangeListener { _, checked ->
+            viewModel.onSymbolsCheckedChange(checked)
         }
     }
 
@@ -71,5 +110,11 @@ class GeneratePasswordActivity : AppCompatActivity() {
             setText(password)
             setSelection(password.length)
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+
+        binding.sliderPasswordLength.clearOnChangeListeners()
     }
 }

--- a/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/GeneratePasswordActivity.kt
+++ b/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/GeneratePasswordActivity.kt
@@ -81,18 +81,7 @@ class GeneratePasswordActivity : AppCompatActivity() {
     }
 
     private fun collectStateFlows() {
-        collectPassword()
         collectViewState()
-    }
-
-    private fun collectPassword() {
-        lifecycleScope.launch {
-            viewModel.password
-                .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
-                .collect {
-                    updatePasswordEditText(it)
-                }
-        }
     }
 
     private fun collectViewState() {

--- a/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/GeneratePasswordActivity.kt
+++ b/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/GeneratePasswordActivity.kt
@@ -31,7 +31,7 @@ class GeneratePasswordActivity : AppCompatActivity() {
             viewModel.generatePassword()
         }
 
-        collectPassword()
+        collectStateFlows()
 
         binding.tilPassword.setEndIconOnClickListener {
             val clipboard = getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
@@ -41,12 +41,27 @@ class GeneratePasswordActivity : AppCompatActivity() {
         }
     }
 
+    private fun collectStateFlows() {
+        collectPassword()
+        collectViewState()
+    }
+
     private fun collectPassword() {
         lifecycleScope.launch {
             viewModel.password
                 .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
                 .collect {
                     updatePasswordEditText(it)
+                }
+        }
+    }
+
+    private fun collectViewState() {
+        lifecycleScope.launch {
+            viewModel.viewState
+                .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+                .collect {
+                    updatePasswordEditText(it.password)
                 }
         }
     }

--- a/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/GeneratePasswordActivity.kt
+++ b/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/GeneratePasswordActivity.kt
@@ -1,18 +1,13 @@
 package com.yogeshpaliyal.keypasscompose.ui.generate
 
-import android.content.ClipData
-import android.content.ClipboardManager
 import android.os.Bundle
-import android.widget.Toast
+import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.flowWithLifecycle
-import androidx.lifecycle.lifecycleScope
-import com.yogeshpaliyal.keypasscompose.R
+import com.google.accompanist.themeadapter.material3.Mdc3Theme
 import com.yogeshpaliyal.keypasscompose.databinding.ActivityGeneratePasswordBinding
+import com.yogeshpaliyal.keypasscompose.ui.generate.ui.GeneratePasswordScreen
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class GeneratePasswordActivity : AppCompatActivity() {
@@ -23,87 +18,11 @@ class GeneratePasswordActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityGeneratePasswordBinding.inflate(layoutInflater)
-        setContentView(binding.root)
 
-        viewModel.generatePassword()
-
-        binding.btnRefresh.setOnClickListener {
-            viewModel.generatePassword()
+        setContent {
+            Mdc3Theme {
+                GeneratePasswordScreen(viewModel)
+            }
         }
-
-        addOnFormChangeListeners()
-        collectStateFlows()
-
-        binding.tilPassword.setEndIconOnClickListener {
-            val clipboard = getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
-            val clip = ClipData.newPlainText("random_password", binding.etPassword.text)
-            clipboard.setPrimaryClip(clip)
-            Toast.makeText(this, getString(R.string.copied_to_clipboard), Toast.LENGTH_SHORT).show()
-        }
-    }
-
-    private fun addOnFormChangeListeners() {
-        onLengthSliderValueChange()
-        onUppercaseCheckedChange()
-        onLowercaseCheckedChange()
-        onNumberCheckedChange()
-        onSymbolCheckedChange()
-    }
-
-    private fun onLengthSliderValueChange() {
-        binding.sliderPasswordLength.addOnChangeListener { _, value, _ ->
-            viewModel.onPasswordLengthSliderChange(value)
-        }
-    }
-
-    private fun onUppercaseCheckedChange() {
-        binding.cbCapAlphabets.setOnCheckedChangeListener { _, checked ->
-            viewModel.onUppercaseCheckedChange(checked)
-        }
-    }
-
-    private fun onLowercaseCheckedChange() {
-        binding.cbLowerAlphabets.setOnCheckedChangeListener { _, checked ->
-            viewModel.onLowercaseCheckedChange(checked)
-        }
-    }
-
-    private fun onNumberCheckedChange() {
-        binding.cbNumbers.setOnCheckedChangeListener { _, checked ->
-            viewModel.onNumbersCheckedChange(checked)
-        }
-    }
-
-    private fun onSymbolCheckedChange() {
-        binding.cbSymbols.setOnCheckedChangeListener { _, checked ->
-            viewModel.onSymbolsCheckedChange(checked)
-        }
-    }
-
-    private fun collectStateFlows() {
-        collectViewState()
-    }
-
-    private fun collectViewState() {
-        lifecycleScope.launch {
-            viewModel.viewState
-                .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
-                .collect {
-                    updatePasswordEditText(it.password)
-                }
-        }
-    }
-
-    private fun updatePasswordEditText(password: String) {
-        binding.etPassword.apply {
-            setText(password)
-            setSelection(password.length)
-        }
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-
-        binding.sliderPasswordLength.clearOnChangeListeners()
     }
 }

--- a/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/GeneratePasswordViewModel.kt
+++ b/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/GeneratePasswordViewModel.kt
@@ -5,6 +5,7 @@ import com.yogeshpaliyal.common.utils.PasswordGenerator
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
@@ -13,7 +14,7 @@ class GeneratePasswordViewModel @Inject constructor() : ViewModel() {
     private val _password = MutableStateFlow("")
     val password = _password.asStateFlow()
 
-    private val _viewState  = MutableStateFlow(GeneratePasswordViewState.Initial)
+    private val _viewState = MutableStateFlow(GeneratePasswordViewState.Initial)
     val viewState = _viewState.asStateFlow()
 
     fun generatePassword() {
@@ -28,5 +29,35 @@ class GeneratePasswordViewModel @Inject constructor() : ViewModel() {
         )
 
         _password.value = passwordGenerator.generatePassword()
+    }
+
+    fun onPasswordLengthSliderChange(value: Float) {
+        _viewState.update {
+            it.copy(length = value.toInt())
+        }
+    }
+
+    fun onUppercaseCheckedChange(checked: Boolean) {
+        _viewState.update {
+            it.copy(includeUppercaseLetters = checked)
+        }
+    }
+
+    fun onLowercaseCheckedChange(checked: Boolean) {
+        _viewState.update {
+            it.copy(includeLowercaseLetters = checked)
+        }
+    }
+
+    fun onNumbersCheckedChange(checked: Boolean) {
+        _viewState.update {
+            it.copy(includeNumbers = checked)
+        }
+    }
+
+    fun onSymbolsCheckedChange(checked: Boolean) {
+        _viewState.update {
+            it.copy(includeSymbols = checked)
+        }
     }
 }

--- a/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/GeneratePasswordViewModel.kt
+++ b/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/GeneratePasswordViewModel.kt
@@ -11,9 +11,6 @@ import javax.inject.Inject
 @HiltViewModel
 class GeneratePasswordViewModel @Inject constructor() : ViewModel() {
 
-    private val _password = MutableStateFlow("")
-    val password = _password.asStateFlow()
-
     private val _viewState = MutableStateFlow(GeneratePasswordViewState.Initial)
     val viewState = _viewState.asStateFlow()
 
@@ -28,7 +25,10 @@ class GeneratePasswordViewModel @Inject constructor() : ViewModel() {
             includeNumbers = currentViewState.includeNumbers,
         )
 
-        _password.value = passwordGenerator.generatePassword()
+        _viewState.update {
+            val newPassword = passwordGenerator.generatePassword()
+            it.copy(password = newPassword)
+        }
     }
 
     fun onPasswordLengthSliderChange(value: Float) {

--- a/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/GeneratePasswordViewModel.kt
+++ b/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/GeneratePasswordViewModel.kt
@@ -1,0 +1,33 @@
+package com.yogeshpaliyal.keypasscompose.ui.generate
+
+import androidx.lifecycle.ViewModel
+import com.yogeshpaliyal.common.utils.PasswordGenerator
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class GeneratePasswordViewModel @Inject constructor() : ViewModel() {
+
+    private val _password = MutableStateFlow("")
+    val password = _password.asStateFlow()
+
+    fun generatePassword(
+        length: Int = 10,
+        includeUppercaseLetters: Boolean = true,
+        includeLowercaseLetters: Boolean = true,
+        includeSymbols: Boolean = true,
+        includeNumbers: Boolean = true,
+    ) {
+        val passwordGenerator = PasswordGenerator(
+            length = length,
+            includeUpperCaseLetters = includeUppercaseLetters,
+            includeLowerCaseLetters = includeLowercaseLetters,
+            includeSymbols = includeSymbols,
+            includeNumbers = includeNumbers,
+        )
+
+        _password.value = passwordGenerator.generatePassword()
+    }
+}

--- a/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/GeneratePasswordViewModel.kt
+++ b/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/GeneratePasswordViewModel.kt
@@ -13,19 +13,18 @@ class GeneratePasswordViewModel @Inject constructor() : ViewModel() {
     private val _password = MutableStateFlow("")
     val password = _password.asStateFlow()
 
-    fun generatePassword(
-        length: Int = 10,
-        includeUppercaseLetters: Boolean = true,
-        includeLowercaseLetters: Boolean = true,
-        includeSymbols: Boolean = true,
-        includeNumbers: Boolean = true,
-    ) {
+    private val _viewState  = MutableStateFlow(GeneratePasswordViewState.Initial)
+    val viewState = _viewState.asStateFlow()
+
+    fun generatePassword() {
+        val currentViewState = _viewState.value
+
         val passwordGenerator = PasswordGenerator(
-            length = length,
-            includeUpperCaseLetters = includeUppercaseLetters,
-            includeLowerCaseLetters = includeLowercaseLetters,
-            includeSymbols = includeSymbols,
-            includeNumbers = includeNumbers,
+            length = currentViewState.length,
+            includeUpperCaseLetters = currentViewState.includeUppercaseLetters,
+            includeLowerCaseLetters = currentViewState.includeLowercaseLetters,
+            includeSymbols = currentViewState.includeSymbols,
+            includeNumbers = currentViewState.includeNumbers,
         )
 
         _password.value = passwordGenerator.generatePassword()

--- a/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/GeneratePasswordViewState.kt
+++ b/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/GeneratePasswordViewState.kt
@@ -1,0 +1,21 @@
+package com.yogeshpaliyal.keypasscompose.ui.generate
+
+data class GeneratePasswordViewState(
+    val length: Int,
+    val includeUppercaseLetters: Boolean,
+    val includeLowercaseLetters: Boolean,
+    val includeSymbols: Boolean,
+    val includeNumbers: Boolean,
+    val password: String,
+) {
+    companion object {
+        val Initial = GeneratePasswordViewState(
+            length = 10,
+            includeUppercaseLetters = true,
+            includeLowercaseLetters = true,
+            includeSymbols = true,
+            includeNumbers = true,
+            password = ""
+        )
+    }
+}

--- a/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/ui/GeneratePasswordContent.kt
+++ b/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/ui/GeneratePasswordContent.kt
@@ -1,0 +1,235 @@
+package com.yogeshpaliyal.keypasscompose.ui.generate.ui
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.themeadapter.material3.Mdc3Theme
+import com.yogeshpaliyal.keypasscompose.ui.generate.GeneratePasswordViewState
+import com.yogeshpaliyal.keypasscompose.ui.generate.ui.components.CheckboxWithLabel
+
+@Composable
+fun GeneratePasswordContent(
+    viewState: GeneratePasswordViewState,
+    onCopyPasswordClick: () -> Unit,
+    onGeneratePasswordClick: () -> Unit,
+    onPasswordLengthChange: (Float) -> Unit,
+    onUppercaseCheckedChange: (Boolean) -> Unit,
+    onLowercaseCheckedChange: (Boolean) -> Unit,
+    onNumbersCheckedChange: (Boolean) -> Unit,
+    onSymbolsCheckedChange: (Boolean) -> Unit,
+) {
+    Scaffold(
+        floatingActionButton = { GeneratePasswordFab(onGeneratePasswordClick) }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+                .background(Color(0xFFEEF0F2))
+                .padding(16.dp)
+        ) {
+            FormInputCard(
+                viewState = viewState,
+                onCopyPasswordClick = onCopyPasswordClick,
+                onPasswordLengthChange = onPasswordLengthChange,
+                onUppercaseCheckedChange = onUppercaseCheckedChange,
+                onLowercaseCheckedChange = onLowercaseCheckedChange,
+                onNumbersCheckedChange = onNumbersCheckedChange,
+                onSymbolsCheckedChange = onSymbolsCheckedChange
+            )
+        }
+    }
+}
+
+@Composable
+private fun GeneratePasswordFab(onGeneratePasswordClick: () -> Unit) {
+    FloatingActionButton(
+        onClick = onGeneratePasswordClick,
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Default.Refresh,
+            contentDescription = ""
+        )
+    }
+}
+
+@Composable
+private fun FormInputCard(
+    viewState: GeneratePasswordViewState,
+    onCopyPasswordClick: () -> Unit,
+    onPasswordLengthChange: (Float) -> Unit,
+    onUppercaseCheckedChange: (Boolean) -> Unit,
+    onLowercaseCheckedChange: (Boolean) -> Unit,
+    onNumbersCheckedChange: (Boolean) -> Unit,
+    onSymbolsCheckedChange: (Boolean) -> Unit
+) {
+    OutlinedCard(
+        colors = CardDefaults.outlinedCardColors(
+            containerColor = Color.White
+        ),
+        shape = RoundedCornerShape(8.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(10.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            PasswordTextField(viewState.password, onCopyPasswordClick)
+
+            // temporary label until we put slider label on the thumb to display current value.
+            PasswordLengthInput(viewState.length, onPasswordLengthChange)
+
+            UppercaseAlphabetInput(viewState.includeUppercaseLetters, onUppercaseCheckedChange)
+
+            LowercaseAlphabetInput(viewState.includeLowercaseLetters, onLowercaseCheckedChange)
+
+            NumberInput(viewState.includeNumbers, onNumbersCheckedChange)
+
+            SymbolInput(viewState.includeSymbols, onSymbolsCheckedChange)
+        }
+    }
+}
+
+@Composable
+private fun PasswordTextField(
+    password: String,
+    onCopyPasswordClick: () -> Unit
+) {
+    OutlinedTextField(
+        value = password,
+        onValueChange = {},
+        modifier = Modifier.fillMaxWidth(),
+        readOnly = true,
+        trailingIcon = {
+            IconButton(
+                onClick = onCopyPasswordClick
+            ) {
+                Icon(
+                    imageVector = Icons.Default.ContentCopy,
+                    contentDescription = "Copy password"
+                )
+            }
+        },
+        label = {
+            Text(text = "Password")
+        }
+    )
+}
+
+@Composable
+private fun PasswordLengthInput(
+    length: Int,
+    onPasswordLengthChange: (Float) -> Unit
+) {
+    Text(text = "Password Length: $length")
+
+    Slider(
+        value = length.toFloat(),
+        onValueChange = onPasswordLengthChange,
+        valueRange = 7f..50f,
+        steps = 43,
+    )
+}
+
+@Composable
+private fun UppercaseAlphabetInput(
+    includeUppercaseLetters: Boolean,
+    onUppercaseCheckedChange: (Boolean) -> Unit
+) {
+    CheckboxWithLabel(
+        label = "Uppercase Alphabets",
+        checked = includeUppercaseLetters,
+        onCheckedChange = onUppercaseCheckedChange,
+    )
+}
+
+@Composable
+private fun LowercaseAlphabetInput(
+    includeLowercaseLetters: Boolean,
+    onLowercaseCheckedChange: (Boolean) -> Unit
+) {
+    CheckboxWithLabel(
+        label = "Lowercase Alphabets",
+        checked = includeLowercaseLetters,
+        onCheckedChange = onLowercaseCheckedChange,
+    )
+}
+
+@Composable
+private fun NumberInput(
+    includeNumbers: Boolean,
+    onNumbersCheckedChange: (Boolean) -> Unit
+) {
+    CheckboxWithLabel(
+        label = "Numbers",
+        checked = includeNumbers,
+        onCheckedChange = onNumbersCheckedChange,
+    )
+}
+
+@Composable
+private fun SymbolInput(
+    includeSymbols: Boolean,
+    onSymbolsCheckedChange: (Boolean) -> Unit
+) {
+    CheckboxWithLabel(
+        label = "Symbols",
+        checked = includeSymbols,
+        onCheckedChange = onSymbolsCheckedChange,
+    )
+}
+
+@Preview(
+    name = "Night Mode",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Preview(
+    name = "Day Mode",
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+)
+@Composable
+@Suppress("UnusedPrivateMember", "MagicNumber")
+private fun GeneratePasswordContentPreview() {
+
+    val viewState = GeneratePasswordViewState.Initial
+
+    Mdc3Theme {
+        Surface {
+            GeneratePasswordContent(
+                viewState = viewState,
+                onGeneratePasswordClick = {},
+                onCopyPasswordClick = {},
+                onPasswordLengthChange = {},
+                onUppercaseCheckedChange = {},
+                onLowercaseCheckedChange = {},
+                onNumbersCheckedChange = {},
+                onSymbolsCheckedChange = {}
+            )
+        }
+    }
+}

--- a/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/ui/GeneratePasswordScreen.kt
+++ b/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/ui/GeneratePasswordScreen.kt
@@ -1,0 +1,43 @@
+package com.yogeshpaliyal.keypasscompose.ui.generate.ui
+
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
+import com.yogeshpaliyal.keypasscompose.R
+import com.yogeshpaliyal.keypasscompose.ui.generate.GeneratePasswordViewModel
+import com.yogeshpaliyal.keypasscompose.ui.generate.ui.utils.copyTextToClipboard
+
+@Composable
+fun GeneratePasswordScreen(viewModel: GeneratePasswordViewModel) {
+
+    val context = LocalContext.current
+
+    // replace collectAsState() with collectAsStateWithLifecycle() when compose version and kotlin version are bumped up.
+    val viewState by viewModel.viewState.collectAsState()
+
+    LaunchedEffect(key1 = Unit) {
+        viewModel.generatePassword()
+    }
+
+    GeneratePasswordContent(
+        viewState = viewState,
+        onGeneratePasswordClick = viewModel::generatePassword,
+        onCopyPasswordClick = { onCopyPasswordClick(context, viewState.password) },
+        onPasswordLengthChange = viewModel::onPasswordLengthSliderChange,
+        onUppercaseCheckedChange = viewModel::onUppercaseCheckedChange,
+        onLowercaseCheckedChange = viewModel::onLowercaseCheckedChange,
+        onNumbersCheckedChange = viewModel::onNumbersCheckedChange,
+        onSymbolsCheckedChange = viewModel::onSymbolsCheckedChange
+    )
+}
+
+private fun onCopyPasswordClick(context: Context, text: String) {
+    copyTextToClipboard(context = context, text = text, label = "random_password")
+    Toast
+        .makeText(context, context.getString(R.string.copied_to_clipboard), Toast.LENGTH_SHORT)
+        .show()
+}

--- a/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/ui/components/CheckboxWithLabel.kt
+++ b/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/ui/components/CheckboxWithLabel.kt
@@ -1,0 +1,32 @@
+package com.yogeshpaliyal.keypasscompose.ui.generate.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun CheckboxWithLabel(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onCheckedChange(!checked) },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Checkbox(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+        )
+
+        Text(text = label)
+    }
+}

--- a/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/ui/utils/ClipboardUtils.kt
+++ b/keypasscompose/src/main/java/com/yogeshpaliyal/keypasscompose/ui/generate/ui/utils/ClipboardUtils.kt
@@ -1,0 +1,17 @@
+package com.yogeshpaliyal.keypasscompose.ui.generate.ui.utils
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import androidx.appcompat.app.AppCompatActivity
+
+fun copyTextToClipboard(
+    context: Context,
+    text: String,
+    label: String
+) {
+    val clipboard =
+        context.getSystemService(AppCompatActivity.CLIPBOARD_SERVICE) as ClipboardManager
+    val clip = ClipData.newPlainText(label, text)
+    clipboard.setPrimaryClip(clip)
+}


### PR DESCRIPTION
Known issues
- The theme of the screen created in compose is different than the one which was built with XML. I tried fixing it using [Mdc3ThemeAdapter](https://google.github.io/accompanist/themeadapter-material/), but it didn't migrate the theme correctly. We have to manually create a new theme for the compose layouts.

- The kotlin version is old and the dependencies not are updated to the latest version because of the same reason. 

Closes #303 