### PR TITLE
Fix: Custom keyphrase setting on backups

### DIFF
--- a/app/src/main/java/com/yogeshpaliyal/keypass/ui/backup/components/CreateCustomKeyphrase.kt
+++ b/app/src/main/java/com/yogeshpaliyal/keypass/ui/backup/components/CreateCustomKeyphrase.kt
@@ -52,9 +52,8 @@ fun CreateCustomKeyphrase(saveKeyphrase: () -> Unit, dismissDialog: () -> Unit) 
 
                 coroutineScope.launch {
                     context.setBackupKey(keyphrase)
+                    saveKeyphrase.invoke()
                 }
-
-                saveKeyphrase.invoke()
             }) {
                 Text(stringResource(id = R.string.yes))
             }


### PR DESCRIPTION
Earlier there was an issue, where users were not able to set the custom keyphrase for backups.
This PR will fix this issue.