### PR TITLE
Update password length to 256

### DIFF
--- a/app/src/main/java/com/yogeshpaliyal/keypass/ui/generate/ui/components/PasswordLengthInput.kt
+++ b/app/src/main/java/com/yogeshpaliyal/keypass/ui/generate/ui/components/PasswordLengthInput.kt
@@ -16,7 +16,7 @@ fun PasswordLengthInput(
     Slider(
         value = length,
         onValueChange = onPasswordLengthChange,
-        valueRange = 7f..50f,
-        steps = 43
+        valueRange = 7f..256f,
+        steps = 249
     )
 }


### PR DESCRIPTION
Fixes #922

Update the password length slider to support a maximum length of 256 characters.

* Change the `valueRange` parameter of the `Slider` component in `PasswordLengthInput.kt` to `7f..256f`.
* Change the `steps` parameter of the `Slider` component in `PasswordLengthInput.kt` to `249`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yogeshpaliyal/KeyPass/issues/922?shareId=6cfce769-5a32-44ce-b4fd-26b001ed2c69).