### PR TITLE
feat: reset password field when moving to confirm password

### DIFF
--- a/app/src/main/java/com/yogeshpaliyal/keypass/ui/auth/AuthScreen.kt
+++ b/app/src/main/java/com/yogeshpaliyal/keypass/ui/auth/AuthScreen.kt
@@ -43,6 +43,15 @@ fun AuthScreen(state: AuthState) {
         dispatchAction(NavigationAction(AuthState.CreatePassword, true))
     }
 
+    // Reset password field when navigating to ConfirmPassword state
+    LaunchedEffect(state) {
+        if (state is AuthState.ConfirmPassword) {
+            password.value = ""
+            passwordVisible.value = false
+            passwordError.value = null
+        }
+    }
+
     LaunchedEffect(key1 = userSettings.keyPassPassword) {
         val mPassword = userSettings.keyPassPassword
         if (mPassword == null) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Password input and related fields are now reset when transitioning to the Confirm Password screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->