### PR TITLE
[CI]: Cancel CI runs that become obsolete

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -13,6 +13,10 @@ on:
       - '**.md'
       - '**.MD'
 
+# If two events are triggered within a short time in the same PR, cancel the run of the oldest event
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   validate-pr:


### PR DESCRIPTION
### Change Summary
Currently, if a PR is open and a push happens, the **PR Check** workflow will start running. If, shortly after a subsequent push on the *same* PR happens, the workflow will start running again without cancelling the previous (now obsolete) run. With these changes, the first run would be cancelled, thus **saving compute resources** (see below for quantity) that can be used to **speed up your overall CI/CD**, without sacrificing functionality, since the second run will contain the changes from the first push as well. 🌱

### Example
Here is an example of the behaviour described above: the commit `e675b70` triggered [this](https://github.com/yogeshpaliyal/KeyPass/actions/runs/14387193262/) workflow run, and shortly after the commit `44dd65b`, that happened on top of the first commit, triggered [this](https://github.com/yogeshpaliyal/KeyPass/actions/runs/14387211093/) workflow. Both workflows ran till the end, spending approximately 9 CPU minutes each. With the proposed changes, the first run would be cancelled, hence saving ~8 CPU minutes and clearing the queue for other workflows. Note that this is an example of a single concurrent run; the accumulated gain for all PRs would be higher, with a lower estimate at **2 CPU hours** over the last few months.

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Kindly let us know (here or in the email below) if you would like more details, if you want to reject the proposed changes for other reasons, or if you have any question whatsoever.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)
konstantinos.kitsios@uzh.ch